### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ZeroDay247/dd060f62-8002-4262-bcb8-2357182d4ae3/513d2b7a-3954-422d-b444-a3e9f1a63d7f/_apis/work/boardbadge/534de579-acfc-4731-ac39-d891de7ba550)](https://dev.azure.com/ZeroDay247/dd060f62-8002-4262-bcb8-2357182d4ae3/_boards/board/t/513d2b7a-3954-422d-b444-a3e9f1a63d7f/Microsoft.RequirementCategory)
 ## Adding to first commit
 
 adding a second line


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#34. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.